### PR TITLE
feat(pix2pix): add inference batching

### DIFF
--- a/src/app/modules/pix2pix/pix2pix.model.ts
+++ b/src/app/modules/pix2pix/pix2pix.model.ts
@@ -134,8 +134,7 @@ export async function translateQueue(queueId: number, image: ImageBitmap | Image
     const now = performance.now();
 
     // Dequeue images up to max batch size
-    const randomBatchSize = Math.floor(Math.random() * MAX_BATCH_SIZE) + 1;
-    const images = imageQueue.splice(0, randomBatchSize);
+    const images = imageQueue.splice(0, MAX_BATCH_SIZE);
 
     const lazyTensor = await translate(images);
     const buffer = await lazyTensor.buffer(); // 60-70ms

--- a/src/app/pages/translate/pose-viewers/human-pose-viewer/human-pose-viewer.component.ts
+++ b/src/app/pages/translate/pose-viewers/human-pose-viewer/human-pose-viewer.component.ts
@@ -77,7 +77,6 @@ export class HumanPoseViewerComponent extends BasePoseViewerComponent implements
               return image;
             });
             const image = await nextFramePromise;
-            await pose.nextFrame();
             this.translateFrame(image, canvas, ctx).then(() => {
               queued--;
               iterFrame();


### PR DESCRIPTION
## Fixes
Relates to #58 

## Description

Since GPUs are highly parallelizable, could we perform inference on multiple frames at once instead of one-by-one?

Yes, we can! However, it does not improve performance much if the GPU is weak.

Benchmark on Macbook Pro with M1 Max, shows no substantial improvement from batching. We observe a linear scale by batch size.

| Batch Size | Fastest (ms) | Slowest (ms) |
|------------|--------------|--------------|
| 1          | 52.4         | 91.2         |
| 2          | 104.2        | 120.5        |
| 3          | 157.1        | 165.0        |
| 5          | 262.5        | 267.3        |
| 6          | 310.5        | 318.0        |