### PR TITLE
fix: On tiny screens, the language-selector is hidden 

### DIFF
--- a/src/app/pages/translate/language-selector/language-selector.component.scss
+++ b/src/app/pages/translate/language-selector/language-selector.component.scss
@@ -40,6 +40,8 @@ ion-button.menu-language-button {
   }
   ion-button.menu-language-button {
     display: block;
+    font-size: calc(0.3vw + 0.5rem);
+
   }
 }
 


### PR DESCRIPTION
## Fixes

Fixes #90  by @AmitMY 

## Description

Adjusts font-size based on  viewport width 

![github-fix#90](https://github.com/sign/translate/assets/40324640/69c10ef4-e1e9-4815-86ae-a3adc6ad1efc)
