### PR TITLE
Fix sitemap generator writing to wrong path

### DIFF
--- a/tools/sitemap-generator.js
+++ b/tools/sitemap-generator.js
@@ -40,7 +40,7 @@ for (const url of additionalUrls) {
 }
 
 async function main() {
-  const buildDir = `${baseDir}dist/sign-translate/browser/`;
+  const buildDir = `${baseDir}${path.sep}dist${path.sep}sign-translate${path.sep}browser${path.sep}`;
 
   // writes sitemaps and index out to the destination you provide.
   await simpleSitemapAndIndex({


### PR DESCRIPTION
baseDir from path.resolve lacked a trailing separator, so the output path resolved to ".../translatedist/..." instead of ".../translate/dist/...".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adjusts how the sitemap output directory is constructed to avoid missing path separators; no changes to sitemap contents or runtime logic beyond path building.
> 
> **Overview**
> Fixes `tools/sitemap-generator.js` to build `buildDir` using `path.sep` segments instead of string concatenation, ensuring the sitemap generator writes to `.../translate/dist/...` rather than an incorrect merged path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52670b6ca528224f28a267919511cc7b6ce96b78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform compatibility for sitemap generation by ensuring proper path handling across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->