### PR TITLE
test: Fix Firefox CI hang in video spec (mock MediaStream)

### DIFF
--- a/src/app/core/modules/ngxs/store/video/video.spec.ts
+++ b/src/app/core/modules/ngxs/store/video/video.spec.ts
@@ -11,7 +11,6 @@ describe('VideoState', () => {
   let navigatorService: NavigatorService;
   let snapshot: {video: VideoStateModel};
 
-  let mockCamera: MediaStream;
   let mockSettings: MediaTrackSettings;
   let mockTrack: MediaStreamVideoTrack;
 
@@ -25,8 +24,8 @@ describe('VideoState', () => {
     };
     mockTrack = {
       getSettings: () => mockSettings,
-      addEventListener: (() => {}) as any,
-    } as MediaStreamVideoTrack;
+      addEventListener: jasmine.createSpy('addEventListener'),
+    } as unknown as MediaStreamVideoTrack;
   });
 
   beforeEach(() => {
@@ -34,8 +33,6 @@ describe('VideoState', () => {
       imports: [],
       providers: [provideStore([VideoState], ngxsConfig), NavigatorService],
     });
-
-    mockCamera = new MediaStream();
 
     store = TestBed.inject(Store);
     navigatorService = TestBed.inject(NavigatorService);
@@ -75,8 +72,7 @@ describe('VideoState', () => {
   });
 
   it('StartCamera error should update store', async () => {
-    const testError = 'testError';
-    const spy = spyOn(navigatorService, 'getCamera').and.throwError(new Error(testError));
+    const spy = spyOn(navigatorService, 'getCamera').and.throwError(new Error('testError'));
 
     snapshot.video.error = null;
     store.reset(snapshot);
@@ -86,20 +82,22 @@ describe('VideoState', () => {
     expect(spy).toHaveBeenCalled();
 
     const error = store.selectSnapshot(state => state.video.error);
-    expect(error).toBe(testError);
+    expect(error).toBe('testError');
   });
 
   it('StartCamera should get camera from navigator', async () => {
-    // Setup mock camera
-    const tracksSpy = spyOn(mockCamera, 'getVideoTracks').and.returnValue([mockTrack]);
+    const tracksSpy = jasmine.createSpy('getVideoTracks').and.returnValue([mockTrack]);
+    const mockCamera = {
+      getVideoTracks: tracksSpy,
+      getTracks: () => [] as MediaStreamTrack[],
+    } as unknown as MediaStream;
     const cameraSpy = spyOn(navigatorService, 'getCamera').and.returnValue(Promise.resolve(mockCamera));
-    const listenerSpy = spyOn(mockTrack, 'addEventListener');
 
     await firstValueFrom(store.dispatch(StartCamera));
 
     expect(tracksSpy).toHaveBeenCalled();
     expect(cameraSpy).toHaveBeenCalled();
-    expect(listenerSpy).toHaveBeenCalled();
+    expect(mockTrack.addEventListener).toHaveBeenCalled();
 
     const {camera, error} = store.selectSnapshot(state => state.video);
 
@@ -108,7 +106,11 @@ describe('VideoState', () => {
   });
 
   it('StartCamera should set camera settings', async () => {
-    const tracksSpy = spyOn(mockCamera, 'getVideoTracks').and.returnValue([mockTrack]);
+    const tracksSpy = jasmine.createSpy('getVideoTracks').and.returnValue([mockTrack]);
+    const mockCamera = {
+      getVideoTracks: tracksSpy,
+      getTracks: () => [] as MediaStreamTrack[],
+    } as unknown as MediaStream;
     const cameraSpy = spyOn(navigatorService, 'getCamera').and.returnValue(Promise.resolve(mockCamera));
 
     await firstValueFrom(store.dispatch(StartCamera));


### PR DESCRIPTION
## Summary

Permanent fix for the Firefox CI failure that's blocking deploys.

`src/app/core/modules/ngxs/store/video/video.spec.ts` created a real `new MediaStream()` and then `spyOn(...)`-ed its native `getVideoTracks` (and a track's `addEventListener`). Firefox marks those native members **non-configurable**, so jasmine can't install the spy — it errors (`getVideoTracks is non-configurable and can't be deleted`) and hangs the browser ~93s until karma reports `DISCONNECTED`, failing the `build` job intermittently (Jasmine's randomized order surfaced the hang at different points).

Fix (matching `rylo-translate`): replace the real `MediaStream`/track with plain mock objects whose methods are `jasmine.createSpy(...)`, so no native non-configurable property is patched. Verified `video.spec.ts` passes 10/10 on **both** Chrome and Firefox locally.

This keeps `--browsers=ChromeHeadless,FirefoxHeadless` in CI, so it **supersedes #254** (the Chrome-only stopgap) — that PR can be closed.

## Test plan

- [x] `video.spec.ts` passes on ChromeHeadless (10/10)
- [x] `video.spec.ts` passes on FirefoxHeadless locally (10/10, previously hung/disconnected)
- [ ] CI `build` green on both browsers → deploy proceeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to mocking strategy; no runtime or security impact.
> 
> **Overview**
> Fixes intermittent **Firefox CI hangs** in `video.spec.ts` by stopping use of `spyOn` on real `MediaStream` / track APIs.
> 
> **StartCamera** tests now use plain mock objects: `getVideoTracks` and track `addEventListener` are **`jasmine.createSpy`** instances on fake `MediaStream` / `MediaStreamVideoTrack` shapes (with `getTracks` stubbed where needed), instead of patching Firefox’s non-configurable native methods. Shared setup drops the global real `MediaStream` mock camera; one **StopVideo** case still seeds state with `new MediaStream()` where no spies are required. Minor test cleanup (inline error string expectations).
> 
> No production code changes—test-only CI stability so dual-browser Karma can stay enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ce47e8532ac95f45b137e5864ba3c3bd661660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved unit test infrastructure for video state management with refined mock implementations and assertions.

*Note: This release contains internal test improvements with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->