### PR TITLE
fix(SIGN-502): Tweak rebrand overlay copy

### DIFF
--- a/src/app/components/rylo-redirect-overlay/rylo-redirect-overlay.component.html
+++ b/src/app/components/rylo-redirect-overlay/rylo-redirect-overlay.component.html
@@ -2,8 +2,8 @@
   <div class="rylo-overlay">
     <div class="rylo-overlay__card" role="dialog" aria-modal="true" aria-labelledby="rylo-overlay-title">
       <div class="rylo-overlay__text">
-        <h1 id="rylo-overlay-title" class="rylo-overlay__title">sign.Translate is now Sign Translate by Rylo.</h1>
-        <p class="rylo-overlay__subtitle">We have our new name and looks but your experience stays the same.</p>
+        <h1 id="rylo-overlay-title" class="rylo-overlay__title">Sign.translate is now part of Rylo</h1>
+        <p class="rylo-overlay__subtitle">We have a new name and look but your experience stays the same.</p>
       </div>
       <a class="rylo-overlay__cta" [href]="redirectUrl" (click)="redirect($event)" autofocus>Try Sign Translate</a>
     </div>


### PR DESCRIPTION
## Summary

Updates the Rylo redirect overlay (shown on sign.mt) copy per SIGN-502, so the messaging reflects that Sign.translate is now part of Rylo.

- **Title:** `sign.Translate is now Sign Translate by Rylo.` → `Sign.translate is now part of Rylo`
- **Subtitle:** `We have our new name and looks but your experience stays the same.` → `We have a new name and look but your experience stays the same.`
- **CTA:** `Try Sign Translate` — unchanged, as requested.

Only the overlay template text changes; no logic or styling is touched.

## Test plan

- [x] Visual diff review — copy matches the requested text in SIGN-502.
- [x] Existing `rylo-redirect-overlay` spec asserts CTA href and native-platform hiding (not the headline text), so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only template text in a marketing overlay; no behavior, routing, or security impact.
> 
> **Overview**
> Updates the **Rylo redirect overlay** headline and subtitle on sign.mt so messaging matches SIGN-502: Sign.translate is framed as **part of Rylo** rather than renamed to “Sign Translate by Rylo,” and the subtitle fixes grammar (“look” vs “looks”).
> 
> The **Try Sign Translate** CTA and all component logic/styling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3082087d7ae7d801217fe5bd76c001628b7672d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated overlay messaging to reflect product rebranding, including the new product name and messaging about the unchanged user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->